### PR TITLE
feature: onAction takes options object; supports allActions flag

### DIFF
--- a/packages/mobx-state-tree/__tests__/core/object.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/object.test.ts
@@ -95,6 +95,9 @@ const createFactoryWithChildren = () => {
         .actions((self) => ({
             rename(value: string) {
                 self.name = value
+            },
+            renameFileAt(index: number, name: string) {
+                self.files[index].rename(name)
             }
         }))
     return Folder
@@ -247,6 +250,28 @@ test("it should emit action calls", () => {
     onAction(doc, (action) => actions.push(action))
     doc.setTo("universe")
     expect(actions).toEqual([{ name: "setTo", path: "", args: ["universe"] }])
+})
+test("it should not emit action calls for children (by default)", () => {
+    const Folder = createFactoryWithChildren()
+    const folder = Folder.create({
+        name: "Photos",
+        files: [{ name: "Photo1" }, { name: "Photo2" }]
+    })
+    let actions: ISerializedActionCall[] = []
+    onAction(folder.files[0], (action) => actions.push(action))
+    folder.renameFileAt(0, "Photo1a")
+    expect(actions.length).toBe(0)
+})
+test("it should emit action calls for children when configured to", () => {
+    const Folder = createFactoryWithChildren()
+    const folder = Folder.create({
+        name: "Photos",
+        files: [{ name: "Photo1" }, { name: "Photo2" }]
+    })
+    let actions: ISerializedActionCall[] = []
+    onAction(folder.files[0], (action) => actions.push(action), { onlyOuter: false })
+    folder.renameFileAt(0, "Photo1a")
+    expect(actions).toEqual([{ name: "rename", path: "", args: ["Photo1a"] }])
 })
 test("it should apply action call", () => {
     const { Factory } = createTestFactories()

--- a/packages/mobx-state-tree/__tests__/core/object.test.ts
+++ b/packages/mobx-state-tree/__tests__/core/object.test.ts
@@ -269,7 +269,7 @@ test("it should emit action calls for children when configured to", () => {
         files: [{ name: "Photo1" }, { name: "Photo2" }]
     })
     let actions: ISerializedActionCall[] = []
-    onAction(folder.files[0], (action) => actions.push(action), { onlyOuter: false })
+    onAction(folder.files[0], (action) => actions.push(action), { allActions: true })
     folder.renameFileAt(0, "Photo1a")
     expect(actions).toEqual([{ name: "rename", path: "", args: ["Photo1a"] }])
 })

--- a/packages/mobx-state-tree/src/index.ts
+++ b/packages/mobx-state-tree/src/index.ts
@@ -44,6 +44,7 @@ export {
     castFlowReturn,
     applyAction,
     onAction,
+    IOnActionOptions,
     IActionRecorder,
     ISerializedActionCall,
     recordActions,

--- a/packages/mobx-state-tree/src/middlewares/on-action.ts
+++ b/packages/mobx-state-tree/src/middlewares/on-action.ts
@@ -220,24 +220,24 @@ export function recordActions(
  *
  * @param target
  * @param listener
- * @param options boolean (legacy attachAfter, default false) or object that controls the behavior
+ * @param options boolean (legacy attachAfter, default false) or object that controls the behavior.
  * @param options.attachAfter (default false) fires the listener *after* the action has executed instead of before.
- * @param options.onlyOuter (default true) only fires the listener for outermost actions
+ * @param options.allActions (default false) fires the listener for *all+ actions instead of just the outermost actions.
  * @returns
  */
-export interface IOnActionOptions { attachAfter?: boolean, onlyOuter?: boolean }
+export interface IOnActionOptions { attachAfter?: boolean, allActions?: boolean }
 export function onAction(
     target: IAnyStateTreeNode,
     listener: (call: ISerializedActionCall) => void,
     attachAfterOrOptions: boolean | IOnActionOptions = false
 ): IDisposer {
     // check all arguments
-    const { attachAfter = false, onlyOuter = true } = typeof attachAfterOrOptions === "object"
+    const { attachAfter = false, allActions = false } = typeof attachAfterOrOptions === "object"
         ? attachAfterOrOptions
         : { attachAfter: attachAfterOrOptions }
     assertIsStateTreeNode(target, 1)
     if (devMode()) {
-        if (onlyOuter && !isRoot(target))
+        if (!allActions && !isRoot(target))
             warnError(
                 "Warning: Attaching onAction listeners to non root nodes is dangerous: No events will be emitted for actions initiated higher up in the tree."
             )
@@ -248,7 +248,7 @@ export function onAction(
     }
 
     return addMiddleware(target, function handler(rawCall, next) {
-        if (rawCall.type === "action" && (!onlyOuter || rawCall.id === rawCall.rootId)) {
+        if (rawCall.type === "action" && (allActions || rawCall.id === rawCall.rootId)) {
             const sourceNode = getStateTreeNode(rawCall.context)
             const info = {
                 name: rawCall.name,

--- a/packages/mobx-state-tree/src/middlewares/on-action.ts
+++ b/packages/mobx-state-tree/src/middlewares/on-action.ts
@@ -187,7 +187,7 @@ export function recordActions(
 
 /**
  * Registers a function that will be invoked for each action that is called on the provided model instance, or to any of its children.
- * See [actions](https://github.com/mobxjs/mobx-state-tree#actions) for more details. onAction events are emitted only for the outermost called action in the stack.
+ * See [actions](https://github.com/mobxjs/mobx-state-tree#actions) for more details. onAction events can be emitted only for the outermost called action in the stack.
  * Action can also be intercepted by middleware using addMiddleware to change the function call before it will be run.
  *
  * Not all action arguments might be serializable. For unserializable arguments, a struct like `{ $MST_UNSERIALIZABLE: true, type: "someType" }` will be generated.
@@ -220,18 +220,24 @@ export function recordActions(
  *
  * @param target
  * @param listener
- * @param attachAfter (default false) fires the listener *after* the action has executed instead of before.
+ * @param options boolean (legacy attachAfter, default false) or object that controls the behavior
+ * @param options.attachAfter (default false) fires the listener *after* the action has executed instead of before.
+ * @param options.onlyOuter (default true) only fires the listener for outermost actions
  * @returns
  */
+export interface IOnActionOptions { attachAfter?: boolean, onlyOuter?: boolean }
 export function onAction(
     target: IAnyStateTreeNode,
     listener: (call: ISerializedActionCall) => void,
-    attachAfter = false
+    attachAfterOrOptions: boolean | IOnActionOptions = false
 ): IDisposer {
     // check all arguments
+    const { attachAfter = false, onlyOuter = true } = typeof attachAfterOrOptions === "object"
+        ? attachAfterOrOptions
+        : { attachAfter: attachAfterOrOptions }
     assertIsStateTreeNode(target, 1)
     if (devMode()) {
-        if (!isRoot(target))
+        if (onlyOuter && !isRoot(target))
             warnError(
                 "Warning: Attaching onAction listeners to non root nodes is dangerous: No events will be emitted for actions initiated higher up in the tree."
             )
@@ -242,7 +248,7 @@ export function onAction(
     }
 
     return addMiddleware(target, function handler(rawCall, next) {
-        if (rawCall.type === "action" && rawCall.id === rawCall.rootId) {
+        if (rawCall.type === "action" && (!onlyOuter || rawCall.id === rawCall.rootId)) {
             const sourceNode = getStateTreeNode(rawCall.context)
             const info = {
                 name: rawCall.name,


### PR DESCRIPTION
By default, MST's `onAction` function registers a callback that is only called for outermost or top-level actions, i.e. if a client calls a method on a `Parent` model which then calls a method on a `Child` model, an `onAction` handler registered with the `Parent` will be called but an `onAction` handler registered on the `Child` will not. MST warns about the potential confusion here by issuing the following warning:

>Warning: Attaching onAction listeners to non root nodes is dangerous: No events will be emitted for actions initiated higher up in the tree.

In CODAP3 we regularly want to respond to actions called on `DataSet`s or other models that are not the root of the hierarchy, and so we used `patch-package` to disable the warning. In CLUE, however, there are parent models that call action methods for `DataSet`s indirectly, which then don't trigger the `onAction` listeners. The proposed fix here is to add an option to the `onAction` function which optionally disables the restriction on only emitting events for outermost actions and hence also disables the warning.

Note: prior to creating this PR branch I synced our fork's `master` branch with the upstream `master` branch, created a new `v5.1.8-cc.x` branch, and merged our previous `v5.1.5-cc.x` branch into it. Upon merging this PR branch into the `v5.1.8-cc.x` branch it should be suitable for publishing the `v5.1.8-cc.1` version.

@emcelroy